### PR TITLE
Update TEDWEB of TED OPEN DATA

### DIFF
--- a/docs/antora/modules/ROOT/pages/index.adoc
+++ b/docs/antora/modules/ROOT/pages/index.adoc
@@ -10,11 +10,11 @@ What is Linked Open Data?::
 Linked Open Data is a method of publishing structured data which places an emphasis on data interoperability, and semantic consistency. As a technology, it is based on the Resource Description Framework (RDF), which is a standard model for data interchange on the Web. 
 +
 Linked Open Data, commonly referred to as "RDF data", can be queried using the SPARQL query language, and is designed to be easily linked to other data sources on the Web.
++
+RDF data can be queried via the https://data.ted.europa.eu/[TED Open Data Service] using SPARQL query language.
 
-What other formats are available?::
-TED notice data are also available in their original XML format, as well as in CSV format. These formats are available for download from the TED Website, and can be searched using the TED Search API.
-
-RDF data can be queried via the https://docs.ted.europa.eu/ted-open-data[TED Open Data Service] using SPARQL query language. Notice data can be downloaded from the https://ted.europa.eu/en/[TED Website]. 
+Reuse TED Data from the TED Website::
+TED notice data are also available in their original XML format, as well as HTML, and PDF. These formats are available for download from the TED Website, and can be searched using the https://ted.europa.eu/api/documentation/index.html[TED Search API].Notice data can be downloaded from the https://ted.europa.eu/en/[TED Website]. 
 
 [.tile-container]
 --

--- a/docs/antora/modules/reuse/pages/index.adoc
+++ b/docs/antora/modules/reuse/pages/index.adoc
@@ -20,8 +20,6 @@ Download bulk notice packages using a direct link
 Bulk downloads in FTP format
 * https://ted.europa.eu/en/simap/developers-corner-for-reusers#download-release-calendar[Download the release calendar] +
 Download the list of the OJS releases per year
-* https://data.europa.eu/data/datasets/ted-csv?locale=en[TED subsets in CSV format] +
-Download yearly bundles in CSV format
 * xref:ftp.adoc[TED schemas archive] +
 The TED schemas archive resources
 


### PR DESCRIPTION
1. https://docs.ted.europa.eu/ODS/latest/index.html

**To reformulate as follows:**


The Publications Office collects a wealth of public procurement data through the notices published in the Supplement of the Official Journal of the EU (OJS). This data is made available to the public as Linked Open Data (LOD) as well as other formats.


What is Linked Open Data?

Linked Open Data is a method of publishing structured data which places an emphasis on data interoperability, and semantic consistency. As a technology, it is based on the Resource Description Framework (RDF), which is a standard model for data interchange on the Web.

Linked Open Data, commonly referred to as "RDF data", can be queried using the SPARQL query language, and is designed to be easily linked to other data sources on the Web. RDF data can be queried via the TED Open Data Service using SPARQL query language.

Reuse TED Data from the TED Website

TED notice data are also available in their original XML format, as well as HTML, and PDF.


These formats are available for download from the TED Website, and can be searched using the TED Search API.

Notice data can be downloaded from the TED Website.

2. https://docs.ted.europa.eu/ODS/latest/reuse/index.html

**To reformulate as follows:**


Reusing TED XML Data from the TED Website

Download of notices in xml format, in daily or monthly packages, can be done from the TED Website. Notices are also available in html, html download, signed pdf, unsigned pdf, and xml, using direct links.

In addition, the Search API can be used in different modes to query notice data. Click on the links below for more detail on the various download methods.

Access Methods · Download notices via the Search API Search and retrieve data published on the TED portal using the TED search API · Downloads notices in various formats using direct links Download bulk notice packages using a direct link · Download XML notices in bulk Download XML notices in bulk via HTTPS · Download the release calendar Download the list of the OJS releases per year · TED schemas archive The TED schemas archive resources

List of search fields used on the TED Site

A comprehensive list of search fields used on the TED website can be viewed via the link below · Search field list